### PR TITLE
refactor: rename IdGenerator class to id

### DIFF
--- a/src/mod.ts
+++ b/src/mod.ts
@@ -5,9 +5,9 @@ import { UuidV7Generator } from "./methods/uuidV7Generator";
 
 /**
  * A utility class for generating various types of IDs.
- * @class IdGenerator
+ * @class id
  */
-export class IdGenerator {
+export class id {
   /**
    * Generates a random ID.
    * @method random


### PR DESCRIPTION
Rename the IdGenerator class to id for improved clarity and 
consistency. This change simplifies the naming convention and 
aligns with the project's style guidelines.